### PR TITLE
add ExtraManagers config to google groups destination

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -56,13 +56,24 @@
     {
       "Name": "Sync from personnel to Google Groups",
       "Source": {
-          "Path": "/user-report"
+        "Path": "/user-report"
       },
       "Destination": {
-          "GroupEmail": "group1@groups.domain.com",
-          "Owners": ["person_a@domain.com","person_b@domain.com"],
-          "Managers": ["another_person@domain.com", "yet-another-person@domain.com"],
-          "ExtraOwners": ["google-admin@domain.com"]
+        "GroupEmail": "group1@groups.domain.com",
+        "Owners": [
+          "person_a@domain.com",
+          "person_b@domain.com"
+        ],
+        "ExtraOwners": [
+          "google-admin@domain.com"
+        ],
+        "Managers": [
+          "another_person@domain.com",
+          "yet-another-person@domain.com"
+        ],
+        "ExtraManagers": [
+          "new-manager@domain.com"
+        ]
       }
     }
   ]

--- a/googledest/google_groups.go
+++ b/googledest/google_groups.go
@@ -46,10 +46,11 @@ type GoogleGroups struct {
 }
 
 type GroupSyncSet struct {
-	GroupEmail  string
-	Owners      []string
-	Managers    []string
-	ExtraOwners []string
+	GroupEmail    string
+	Owners        []string
+	ExtraOwners   []string
+	Managers      []string
+	ExtraManagers []string
 }
 
 func NewGoogleGroupsDestination(destinationConfig personnel_sync.DestinationConfig) (personnel_sync.Destination, error) {
@@ -108,7 +109,10 @@ func (g *GoogleGroups) ListUsers() ([]personnel_sync.Person, error) {
 	var members []personnel_sync.Person
 
 	for _, nextMember := range membersList {
-		// Do not include ExtraOwners in list to prevent inclusion in delete list
+		// Do not include Extra Managers or ExtraOwners in list to prevent inclusion in delete list
+		if isExtraManager, _ := personnel_sync.InArray(nextMember.Email, g.GroupSyncSet.ExtraManagers); isExtraManager {
+			continue
+		}
 		if isExtraOwner, _ := personnel_sync.InArray(nextMember.Email, g.GroupSyncSet.ExtraOwners); isExtraOwner {
 			continue
 		}
@@ -149,7 +153,10 @@ func (g *GoogleGroups) ApplyChangeSet(
 		}
 	}
 
-	// Add any ExtraOwners to Create list since they are not in the source people
+	// Add any ExtraManagers and ExtraOwners to Create list since they are not in the source people
+	for _, manager := range g.GroupSyncSet.ExtraManagers {
+		toBeCreated[manager] = RoleManager
+	}
 	for _, owner := range g.GroupSyncSet.ExtraOwners {
 		toBeCreated[owner] = RoleOwner
 	}
@@ -164,7 +171,10 @@ func (g *GoogleGroups) ApplyChangeSet(
 	}
 
 	for _, dp := range changes.Delete {
-		// Do not delete ExtraOwners
+		// Do not delete ExtraManagers or ExtraOwners
+		if isExtraManager, _ := personnel_sync.InArray(dp.CompareValue, g.GroupSyncSet.ExtraManagers); isExtraManager {
+			continue
+		}
 		if isExtraOwner, _ := personnel_sync.InArray(dp.CompareValue, g.GroupSyncSet.ExtraOwners); isExtraOwner {
 			continue
 		}

--- a/lambda-example/config.example.json
+++ b/lambda-example/config.example.json
@@ -59,8 +59,10 @@
       "Destination": {
         "GroupEmail": "group1@groups.domain.com",
         "Owners": ["person_a@domain.com","person_b@domain.com"],
+        "ExtraOwners": ["google-admin@domain.com"],
         "Managers": ["another_person@domain.com", "yet-another-person@domain.com"],
-        "ExtraOwners": ["google-admin@domain.com"]
+        "ExtraManagers": ["new_manager@domain.com"]
+
       }
     }
   ]


### PR DESCRIPTION
google admins don't want group members to be "owners" of the group but "managers" so they can post messages but not fully administer group. 