### PR TITLE
add v3 to the module path

### DIFF
--- a/cmd/syncpeeps.go
+++ b/cmd/syncpeeps.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/silinternational/personnel-sync/restapi"
+	"github.com/silinternational/personnel-sync/v3/restapi"
 
-	"github.com/silinternational/personnel-sync/webhelpdesk"
+	"github.com/silinternational/personnel-sync/v3/webhelpdesk"
 
-	"github.com/silinternational/personnel-sync/googledest"
+	"github.com/silinternational/personnel-sync/v3/googledest"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/silinternational/personnel-sync
+module github.com/silinternational/personnel-sync/v3
 
 go 1.14
 

--- a/googledest/contacts.go
+++ b/googledest/contacts.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 const MaxQuerySize = 10000

--- a/googledest/contacts_test.go
+++ b/googledest/contacts_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 func TestNewGoogleContactsDestination(t *testing.T) {

--- a/googledest/google_groups.go
+++ b/googledest/google_groups.go
@@ -9,7 +9,7 @@ import (
 
 	admin "google.golang.org/api/admin/directory/v1"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 	"golang.org/x/net/context"
 )
 

--- a/googledest/google_groups_test.go
+++ b/googledest/google_groups_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 	admin "google.golang.org/api/admin/directory/v1"
 )
 

--- a/googledest/users.go
+++ b/googledest/users.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 	"golang.org/x/net/context"
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/googleapi"

--- a/googledest/users_test.go
+++ b/googledest/users_test.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/api/googleapi"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 	admin "google.golang.org/api/admin/directory/v1"
 )
 

--- a/lambda-example/go.mod
+++ b/lambda-example/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/aws/aws-lambda-go v1.16.0
-	github.com/silinternational/personnel-sync v3.2.0+incompatible
+	github.com/silinternational/personnel-sync/v3 v3.3.1
 	golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 // indirect
 	google.golang.org/api v0.24.0 // indirect
 )

--- a/lambda-example/personnelsync.go
+++ b/lambda-example/personnelsync.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"time"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
-	"github.com/silinternational/personnel-sync/googledest"
-	"github.com/silinternational/personnel-sync/restapi"
-	"github.com/silinternational/personnel-sync/webhelpdesk"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
+	"github.com/silinternational/personnel-sync/v3/googledest"
+	"github.com/silinternational/personnel-sync/v3/restapi"
+	"github.com/silinternational/personnel-sync/v3/webhelpdesk"
 
 	"github.com/aws/aws-lambda-go/lambda"
 )

--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Jeffail/gabs"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 const AuthTypeBasic = "basic"

--- a/restapi/restapi_test.go
+++ b/restapi/restapi_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 func TestRestAPI_ListUsers(t *testing.T) {

--- a/webhelpdesk/webhelpdesk.go
+++ b/webhelpdesk/webhelpdesk.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 const DefaultBatchSize = 50

--- a/webhelpdesk/webhelpdesk_test.go
+++ b/webhelpdesk/webhelpdesk_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/silinternational/personnel-sync/restapi"
+	"github.com/silinternational/personnel-sync/v3/restapi"
 
-	personnel_sync "github.com/silinternational/personnel-sync"
+	personnel_sync "github.com/silinternational/personnel-sync/v3"
 )
 
 func TestWebHelpDesk_ListUsers(t *testing.T) {


### PR DESCRIPTION
Go modules requires major versions greater than v1 to include the major version number in the import path.