### PR TITLE
Release 5.1.0

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -74,10 +74,11 @@ func sendAnEmail(emailMsg ses.Message, recipient string, config Config) error {
 		Source:  aws.String(config.ReturnToAddr),
 	}
 
-	sess, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(config.AWSAccessKeyID, config.AWSSecretAccessKey, ""),
-		Region:      aws.String(config.AWSRegion)},
-	)
+	cfg := &aws.Config{Region: aws.String(config.AWSRegion)}
+	if config.AWSAccessKeyID != "" && config.AWSSecretAccessKey != "" {
+		cfg.Credentials = credentials.NewStaticCredentials(config.AWSAccessKeyID, config.AWSSecretAccessKey, "")
+	}
+	sess, err := session.NewSession(cfg)
 	if err != nil {
 		return fmt.Errorf("error creating AWS session: %s", err)
 	}


### PR DESCRIPTION
If AWS SES credentials are not provided in config.json, revert to default, processed in the following order:

1. Environment variables.
2. Shared credentials file.
3. If your application uses an ECS task definition or RunTask API operation, IAM role for tasks.
4. If your application is running on an Amazon EC2 instance, IAM role for Amazon EC2.

https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials