### PR TITLE
add search and replace feature to the attribute map

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 SIL International
+Copyright (c) 2019-2021 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ provider:
       Resource: "*"
 ```
 
-Both authentication mechanisms are provided in the `lamdda-example` directory, 
+Both authentication mechanisms are provided in the `lambda-example` directory, 
 but only one is needed.
 
 ### Exporting logs from CloudWatch

--- a/alert/alert.go
+++ b/alert/alert.go
@@ -58,7 +58,7 @@ func SendEmail(config Config, body string) {
 
 	if lastError != "" {
 		addresses := strings.Join(badRecipients, ", ")
-		log.Printf("Error sending Cloudflare scanner email from %s to: %s\n %s",
+		log.Printf("Error sending email from '%s' to '%s': %s",
 			config.ReturnToAddr, addresses, lastError)
 	}
 }

--- a/google/groups.go
+++ b/google/groups.go
@@ -15,9 +15,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-const RoleMember = "MEMBER"
-const RoleOwner = "OWNER"
-const RoleManager = "MANAGER"
+const (
+	RoleMember  = "MEMBER"
+	RoleOwner   = "OWNER"
+	RoleManager = "MANAGER"
+)
 
 type GoogleGroups struct {
 	DestinationConfig internal.DestinationConfig
@@ -209,7 +211,8 @@ func (g *GoogleGroups) addMember(
 	if err != nil && !strings.Contains(err.Error(), "409") { // error code 409 is for existing user
 		eventLog <- internal.EventLogItem{
 			Level:   syslog.LOG_ERR,
-			Message: fmt.Sprintf("unable to insert %s in Google group %s: %s", email, g.GroupSyncSet.GroupEmail, err.Error())}
+			Message: fmt.Sprintf("unable to insert %s in Google group %s: %s", email, g.GroupSyncSet.GroupEmail, err.Error()),
+		}
 		return
 	}
 
@@ -233,7 +236,8 @@ func (g *GoogleGroups) removeMember(
 	if err != nil {
 		eventLog <- internal.EventLogItem{
 			Level:   syslog.LOG_ERR,
-			Message: fmt.Sprintf("unable to delete %s from Google group %s: %s", email, g.GroupSyncSet.GroupEmail, err.Error())}
+			Message: fmt.Sprintf("unable to delete %s from Google group %s: %s", email, g.GroupSyncSet.GroupEmail, err.Error()),
+		}
 		return
 	}
 

--- a/internal/types.go
+++ b/internal/types.go
@@ -19,6 +19,8 @@ type AttributeMap struct {
 	Destination   string
 	Required      bool
 	CaseSensitive bool
+	Expression    string // regular expression
+	Replace       string // replace string
 }
 
 type SourceConfig struct {

--- a/sync.go
+++ b/sync.go
@@ -77,7 +77,11 @@ func RunSync(configFile string) error {
 
 	// Iterate through SyncSets and process changes
 	for i, syncSet := range appConfig.SyncSets {
-		prefix := fmt.Sprintf("[%-*s] ", maxNameLength, syncSet.Name)
+		if syncSet.Name == "" {
+			msg := "configuration contains a set with no name"
+			errors = append(errors, msg)
+		}
+		prefix := fmt.Sprintf("[ %-*s ] ", maxNameLength, syncSet.Name)
 		syncSetLogger := log.New(os.Stdout, prefix, 0)
 		syncSetLogger.Printf("(%v/%v) Beginning sync set", i+1, len(appConfig.SyncSets))
 


### PR DESCRIPTION
If the source data has a null attribute value, no update happens. On one of the sync instances, we needed to empty out an old attribute, so will do something like this:

```json
  "AttributeMap": [
    {
      "Source": "Blank_Field",
      "Destination": "costCenter",
      "Expression": ".*",
      "Replace": ""
    }
  ]
```
