### PR TITLE
add Required property on Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ record is not included in the output data.
 - Attribute -- The name of the attribute to filter on. Does not need to be listed in the sync attributes.
 - Expression -- A text expression for which to search. Uses RE2 regular expression syntax.
 - Exclude -- If true, records matching the expression are excluded.
-- Required -- If true, and Attribute is missing or null, an error will be logged and the sync will fail.
+- Nullable -- If false, and Attribute is missing or null, an error will be logged and the sync will fail.
 
 #### Example config
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ record is not included in the output data.
 - Attribute -- The name of the attribute to filter on. Does not need to be listed in the sync attributes.
 - Expression -- A text expression for which to search. Uses RE2 regular expression syntax.
 - Exclude -- If true, records matching the expression are excluded.
+- Required -- If true, and Attribute is missing or null, an error will be logged and the sync will fail.
 
 #### Example config
 

--- a/internal/filter.go
+++ b/internal/filter.go
@@ -12,6 +12,7 @@ type Filter struct {
 	Expression         string
 	Exclude            bool
 	compiledExpression *regexp.Regexp
+	Required           bool
 }
 
 func (f Filter) Matches(value string) bool {

--- a/internal/filter.go
+++ b/internal/filter.go
@@ -12,7 +12,7 @@ type Filter struct {
 	Expression         string
 	Exclude            bool
 	compiledExpression *regexp.Regexp
-	Required           bool
+	Nullable           bool
 }
 
 func (f Filter) Matches(value string) bool {

--- a/internal/person.go
+++ b/internal/person.go
@@ -17,7 +17,7 @@ func (p *Person) Matches(filters Filters) (bool, error) {
 	match := true
 	for _, f := range filters {
 		value, ok := p.Attributes[f.Attribute]
-		if !ok {
+		if !ok && f.Required {
 			missingAttributes = append(missingAttributes, f.Attribute)
 		}
 		if !f.Matches(value) {

--- a/internal/person.go
+++ b/internal/person.go
@@ -17,7 +17,7 @@ func (p *Person) Matches(filters Filters) (bool, error) {
 	match := true
 	for _, f := range filters {
 		value, ok := p.Attributes[f.Attribute]
-		if !ok && f.Required {
+		if !ok && !f.Nullable {
 			missingAttributes = append(missingAttributes, f.Attribute)
 		}
 		if !f.Matches(value) {

--- a/internal/person_test.go
+++ b/internal/person_test.go
@@ -71,13 +71,13 @@ func TestPerson_Matches(t *testing.T) {
 		{
 			name:    "missing attribute, not required",
 			person:  Person{Attributes: map[string]string{"attr": "val"}},
-			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Required: false}},
+			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Nullable: true}},
 			wantErr: false,
 		},
 		{
 			name:    "missing attribute, required",
 			person:  Person{Attributes: map[string]string{"attr": "val"}},
-			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Required: true}},
+			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Nullable: false}},
 			wantErr: true,
 		},
 	}

--- a/internal/person_test.go
+++ b/internal/person_test.go
@@ -69,9 +69,15 @@ func TestPerson_Matches(t *testing.T) {
 			want: false,
 		},
 		{
-			name:    "missing attribute",
+			name:    "missing attribute, not required",
 			person:  Person{Attributes: map[string]string{"attr": "val"}},
-			filters: Filters{Filter{Attribute: "other_attr", Expression: "value"}},
+			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Required: false}},
+			wantErr: false,
+		},
+		{
+			name:    "missing attribute, required",
+			person:  Person{Attributes: map[string]string{"attr": "val"}},
+			filters: Filters{Filter{Attribute: "other_attr", Expression: "value", Required: true}},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Encountered a situation where the data is nullable, which was interpreted as a missing attribute. Adding `"Required": false`  silences the error.