### PR TITLE
Don't include empty attribute in attribute list.

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -288,8 +288,10 @@ func RunSyncSet(logger *log.Logger, source Source, destination Destination, conf
 
 func GetSourceAttributes(attrMap []AttributeMap) []string {
 	var keys []string
-	for _, attrMap := range attrMap {
-		keys = append(keys, attrMap.Source)
+	for _, attr := range attrMap {
+		if attr.Source != "" {
+			keys = append(keys, attr.Source)
+		}
 	}
 
 	return keys
@@ -297,8 +299,10 @@ func GetSourceAttributes(attrMap []AttributeMap) []string {
 
 func GetDestinationAttributes(attrMap []AttributeMap) []string {
 	var keys []string
-	for _, attrMap := range attrMap {
-		keys = append(keys, attrMap.Destination)
+	for _, attr := range attrMap {
+		if attr.Destination != "" {
+			keys = append(keys, attr.Destination)
+		}
 	}
 
 	return keys


### PR DESCRIPTION
In a case where a source attribute used with a replace expression that doesn't use group substitution. Probably not valid for destination attributes, but it's cleaner anyway.