### PR TITLE
Hotfix Release 6.3.2

### DIFF
--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -294,7 +294,7 @@ func (r *RestAPI) requestPage(desiredAttrs []string, url string, errLog chan<- s
 	var peopleList []*gabs.Container
 	if r.ResultsJSONContainer != "" {
 		// Get children records based on ResultsJSONContainer from config
-		peopleList = jsonParsed.S(r.ResultsJSONContainer).Children()
+		peopleList = jsonParsed.Path(r.ResultsJSONContainer).Children()
 	} else {
 		// Root level should contain array of children records
 		peopleList = jsonParsed.Children()


### PR DESCRIPTION
### Fixed
- The `Jeffail/gabs` function `S` (which is an alias for `Search`) does not support dot-separated JSON paths. Use the proper function `Path` instead.