### PR TITLE
Release 6.8.1 - fix workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-    - "**"
 
 jobs:
   test:


### PR DESCRIPTION
### Fixed
- Remove `branches: "**"` from the workflow config so the workflow will run on all pushes.