### PR TITLE
Release 6.8.2 -- add crucial steps to the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
       - name: Fetch all tags
         run: git fetch --force --tags
 


### PR DESCRIPTION
### Fixed
- The release job needed checkout and setup-go also