### PR TITLE
Release 6.8.3 -- fix GoReleaser error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ config*.json
 .vscode
 
 lambda-example/go.mod
+
+# GoReleaser build output
+dist/

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/silinternational/personnel-sync/v6
 
 go 1.20
 
-replace github.com/silinternational/personnel-sync/v6 => ./
-
 require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/aws/aws-lambda-go v1.46.0


### PR DESCRIPTION
### Removed
- Removed `replace` directive from go.mod

--

Error message:
```
 your go.mod file has replace directive in it, and go mod proxying is enabled - this does not work, and you need to either disable it or remove the replace directive
    • the offending line is replace github.com/silinternational/personnel-sync/v6 => ./
  ⨯ release failed after 1s                  error=cannot use the go.mod replace directive with go mod proxy enabled
```