### PR TITLE
Fix Source and Destination AttributeMap field names in example config

### DIFF
--- a/lambda-example/config.example.json
+++ b/lambda-example/config.example.json
@@ -35,18 +35,18 @@
   },
   "AttributeMap": [
     {
-      "SourceName": "First_Name",
-      "DestinationName": "givenName",
+      "Source": "First_Name",
+      "Destination": "givenName",
       "required": true
     },
     {
-      "SourceName": "Last_Name",
-      "DestinationName": "sn",
+      "Source": "Last_Name",
+      "Destination": "sn",
       "required": true
     },
     {
-      "SourceName": "Email",
-      "DestinationName": "mail",
+      "Source": "Email",
+      "Destination": "mail",
       "required": true
     }
   ],


### PR DESCRIPTION
### Fixed
- Fix `Source` and `Destination` AttributeMap field names in example config

---

See [here](https://github.com/silinternational/personnel-sync/tree/develop?tab=readme-ov-file#attributemap) for documentation.