### PR TITLE
Release 6.8.5 -- fix the RestAPI adapter ID handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ In the [Google Developer Console](https://console.developers.google.com) ...
   * For the Google Users adapter, enable "Admin SDK"
   * For the Google Groups adapter, enable "Admin SDK"
   * For the Google Contacts adapter, enable "Contacts API"
+  * For the Google Sheets adapter, enable "Google Sheets API"
 * Create a new Service Account and a corresponding JSON credential file, which should contain something like this:
 
 ```json
@@ -774,7 +775,7 @@ In Google Admin, Security, [API Controls](https://admin.google.com/ac/owl?hl=en)
   `https://www.googleapis.com/auth/admin.directory.group.member`
 * The API Scope required for Google Contacts is: `https://www.google.com/m8/feeds/contacts/`
 * The API Scope required for Google User Directory is: `https://www.googleapis.com/auth/admin.directory.user`
-* Google Sheets does not require Domain-wide Delegation. Instead, share the sheet with the service account. Note: it will say the user is not in the organization. This warning can be ignored.
+* Google Sheets does not require Domain-wide Delegation. Instead, share the sheet with the service account. Note: it will say the user is not in the organization. This warning can be ignored. If you do add a `DelegatedAdminEmail` address, you must use the API Scope https://www.googleapis.com/auth/spreadsheets which will grant admin access to all sheets.
 
 The sync job will need to use the Service Account credentials to impersonate another user that has
 appropriate domain privileges and who has logged in at least once into Google Workspace and

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -134,6 +134,9 @@ func GenerateChangeSet(logger *log.Logger, sourcePeople, destinationPeople []Per
 
 		if !personAttributesAreEqual(logger, sp, destinationPerson, config) {
 			sp.ID = destinationPerson.Attributes["id"]
+			if destinationPerson.ID != "" { // use ID if it is set to something else
+				sp.ID = destinationPerson.ID
+			}
 			changeSet.Update = append(changeSet.Update, sp)
 			continue
 		}


### PR DESCRIPTION
[ITSE-1470](https://itse.youtrack.cloud/issue/ITSE-1470) Fix personnel-sync to use specified attribute name in update and delete paths

---

### Fixed
- Fixed the `IDAttribute` configuration property. It was not used when creating and updating a RestAPI record, but instead was using the `id` attribute.