### PR TITLE
Release 6.8.7  -- Minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,9 +617,9 @@ Example config:
 Note: `Source` fields should be adjusted to fit the actual source adapter.
 
 ### Google Users
-This destination can update User records in the Google Directory. The compare
-attribute is `email` (`primaryEmail`). A limited subset of user properties are
-available to be updated. 
+This destination can update User records in the Google Directory. Create and
+delete are not yet implemented. The compare attribute is `email` (`primaryEmail`).
+A limited subset of user properties are available to be updated. 
 
 | property   | Google property | Google sub-property | Google type  |
 |------------|-----------------|---------------------|--------------|

--- a/google/groups.go
+++ b/google/groups.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/syslog"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -112,13 +113,9 @@ func (g *GoogleGroups) ListUsers(desiredAttrs []string) ([]internal.Person, erro
 
 	for _, nextMember := range membersList {
 		// Do not include ExtraManager, ExtraOwners, or ExtraMember in list to prevent inclusion in delete list
-		if isExtraManager, _ := internal.InArray(nextMember.Email, g.GroupSyncSet.ExtraManagers); isExtraManager {
-			continue
-		}
-		if isExtraOwner, _ := internal.InArray(nextMember.Email, g.GroupSyncSet.ExtraOwners); isExtraOwner {
-			continue
-		}
-		if isExtraMember, _ := internal.InArray(nextMember.Email, g.GroupSyncSet.ExtraMembers); isExtraMember {
+		if slices.Contains(g.GroupSyncSet.ExtraManagers, nextMember.Email) ||
+			slices.Contains(g.GroupSyncSet.ExtraOwners, nextMember.Email) ||
+			slices.Contains(g.GroupSyncSet.ExtraMembers, nextMember.Email) {
 			continue
 		}
 
@@ -183,13 +180,9 @@ func (g *GoogleGroups) ApplyChangeSet(
 	if !g.GroupSyncSet.DisableDelete {
 		for _, dp := range changes.Delete {
 			// Do not delete ExtraManagers, ExtraOwners, or ExtraMembers
-			if isExtraManager, _ := internal.InArray(dp.CompareValue, g.GroupSyncSet.ExtraManagers); isExtraManager {
-				continue
-			}
-			if isExtraOwner, _ := internal.InArray(dp.CompareValue, g.GroupSyncSet.ExtraOwners); isExtraOwner {
-				continue
-			}
-			if isExtraMember, _ := internal.InArray(dp.CompareValue, g.GroupSyncSet.ExtraMembers); isExtraMember {
+			if slices.Contains(g.GroupSyncSet.ExtraManagers, dp.CompareValue) ||
+				slices.Contains(g.GroupSyncSet.ExtraOwners, dp.CompareValue) ||
+				slices.Contains(g.GroupSyncSet.ExtraMembers, dp.CompareValue) {
 				continue
 			}
 			wg.Add(1)

--- a/google/groups.go
+++ b/google/groups.go
@@ -111,7 +111,7 @@ func (g *GoogleGroups) ListUsers(desiredAttrs []string) ([]internal.Person, erro
 	var members []internal.Person
 
 	for _, nextMember := range membersList {
-		// Do not include Extra Managers or ExtraOwners in list to prevent inclusion in delete list
+		// Do not include ExtraManager, ExtraOwners, or ExtraMember in list to prevent inclusion in delete list
 		if isExtraManager, _ := internal.InArray(nextMember.Email, g.GroupSyncSet.ExtraManagers); isExtraManager {
 			continue
 		}

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -3,26 +3,15 @@ package internal
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 )
 
 func AddStringToSlice(newString string, slice []string) []string {
-	if !IsStringInSlice(newString, slice) {
+	if !slices.Contains(slice, newString) {
 		slice = append(slice, newString)
 	}
 	return slice
-}
-
-// IsStringInSlice iterates over a slice of strings, looking for the given
-// string. If found, true is returned. Otherwise, false is returned.
-func IsStringInSlice(needle string, haystack []string) bool {
-	for _, hs := range haystack {
-		if needle == hs {
-			return true
-		}
-	}
-
-	return false
 }
 
 // AddParamsToURL returns the input url string if there are no params to add

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -46,49 +46,6 @@ func TestAddStringToSlice(t *testing.T) {
 	}
 }
 
-func TestIsStringInSlice(t *testing.T) {
-	type testData struct {
-		name     string
-		needle   string
-		haystack []string
-		want     bool
-	}
-
-	allTestData := []testData{
-		{
-			name:     "empty haystack",
-			needle:   "no",
-			haystack: []string{},
-			want:     false,
-		},
-		{
-			name:     "not in haystack",
-			needle:   "no",
-			haystack: []string{"really", "are you sure"},
-			want:     false,
-		},
-		{
-			name:     "in one element haystack",
-			needle:   "yes",
-			haystack: []string{"yes"},
-			want:     true,
-		},
-		{
-			name:     "in longer haystack",
-			needle:   "yes",
-			haystack: []string{"one", "two", "three", "yes"},
-			want:     true,
-		},
-	}
-
-	for i, td := range allTestData {
-		t.Run(td.name, func(t *testing.T) {
-			got := IsStringInSlice(td.needle, td.haystack)
-			require.Equal(t, td.want, got, "incorrect value for test %v", i)
-		})
-	}
-}
-
 func TestAddParamsToURL(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -224,9 +224,6 @@ func RunSyncSet(logger *log.Logger, source Source, destination Destination, conf
 
 	results := destination.ApplyChangeSet(changeSet, eventLog)
 
-	logger.Printf("Sync results: %v users added, %v users updated, %v users removed\n",
-		results.Created, results.Updated, results.Deleted)
-
 	for i := 0; i < 100; i++ {
 		time.Sleep(time.Millisecond * 10)
 		if len(eventLog) == 0 {
@@ -234,6 +231,9 @@ func RunSyncSet(logger *log.Logger, source Source, destination Destination, conf
 		}
 	}
 	close(eventLog)
+
+	logger.Printf("Sync results: %v users added, %v users updated, %v users removed\n",
+		results.Created, results.Updated, results.Deleted)
 
 	return nil
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -224,7 +224,7 @@ func RunSyncSet(logger *log.Logger, source Source, destination Destination, conf
 
 	results := destination.ApplyChangeSet(changeSet, eventLog)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		time.Sleep(time.Millisecond * 10)
 		if len(eventLog) == 0 {
 			break

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"log/syslog"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -284,30 +283,6 @@ func printChangeSet(logger *log.Logger, changeSet ChangeSet) {
 	for i, user := range changeSet.Delete {
 		logger.Printf("  delete %v) %s", i+1, user.CompareValue)
 	}
-}
-
-// This function will search element inside array with any type.
-// Will return boolean and index for matched element.
-// True and index more than 0 if element is exist.
-// needle is element to search, haystack is slice of value to be search.
-func InArray(needle, haystack any) (exists bool, index int) {
-	exists = false
-	index = -1
-
-	switch reflect.TypeOf(haystack).Kind() {
-	case reflect.Slice:
-		s := reflect.ValueOf(haystack)
-
-		for i := 0; i < s.Len(); i++ {
-			if reflect.DeepEqual(needle, s.Index(i).Interface()) {
-				index = i
-				exists = true
-				return
-			}
-		}
-	}
-
-	return
 }
 
 type EmptyDestination struct{}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -143,7 +143,7 @@ func TestBatchTimer(t *testing.T) {
 		bTimer := NewBatchTimer(testRun.batchSize, testRun.secondsPerBatch)
 		startTime := time.Now()
 
-		for i := 0; i < testRun.numberOfCalls; i++ {
+		for range testRun.numberOfCalls {
 			DoNothing()
 			bTimer.WaitOnBatch()
 		}

--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -158,7 +158,7 @@ func (r *RestAPI) ApplyChangeSet(changes internal.ChangeSet, eventLog chan<- int
 	batchTimer := internal.NewBatchTimer(r.BatchSize, r.BatchDelaySeconds)
 
 	if r.destinationConfig.DisableAdd {
-		log.Println("Contact creation is disabled.")
+		log.Println("Creation is disabled.")
 	} else {
 		for _, toCreate := range changes.Create {
 			wg.Add(1)


### PR DESCRIPTION
### Changed
- Wait to print summary message in case more log events are queued.
- Use range int syntax
- Use `slices.Contains` in place of home-built functions

### Fixed
- Correct minor errors in a comment about ExtraMember config
