### PR TITLE
wait for rate limiting in restapi listUsersForPath

### DIFF
--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -483,13 +483,18 @@ func (r *RestAPI) validateConfig() error {
 	if r.BatchSize <= 0 {
 		r.BatchSize = DefaultBatchSize
 	}
+
 	if r.BatchDelaySeconds <= 0 {
 		r.BatchDelaySeconds = DefaultBatchDelaySeconds
 	}
-	if r.Pagination.Scheme != PaginationSchemeItems && r.Pagination.Scheme != PaginationSchemePages {
+
+	switch r.Pagination.Scheme {
+	case "", PaginationSchemeItems, PaginationSchemePages:
+	default:
 		return fmt.Errorf("invalid pagination scheme (%s), must be %s or %s",
 			r.Pagination.Scheme, PaginationSchemeItems, PaginationSchemePages)
 	}
+
 	return r.Filters.Validate()
 }
 

--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -212,14 +212,6 @@ func (r *RestAPI) listUsersForPath(
 		return
 	}
 
-	if scheme != PaginationSchemeItems && scheme != PaginationSchemePages {
-		msg := fmt.Sprintf("invalid pagination scheme (%s), must be %s or %s",
-			r.Pagination.Scheme, PaginationSchemeItems, PaginationSchemePages)
-		log.Println(msg)
-		errLog <- msg
-		return
-	}
-
 	batchCounter := 0
 	for i := r.Pagination.FirstIndex; i <= r.Pagination.PageLimit; i++ {
 		nextIndex := i
@@ -493,6 +485,10 @@ func (r *RestAPI) validateConfig() error {
 	}
 	if r.BatchDelaySeconds <= 0 {
 		r.BatchDelaySeconds = DefaultBatchDelaySeconds
+	}
+	if r.Pagination.Scheme != PaginationSchemeItems && r.Pagination.Scheme != PaginationSchemePages {
+		return fmt.Errorf("invalid pagination scheme (%s), must be %s or %s",
+			r.Pagination.Scheme, PaginationSchemeItems, PaginationSchemePages)
 	}
 	return r.Filters.Validate()
 }

--- a/restapi/restapi.go
+++ b/restapi/restapi.go
@@ -220,6 +220,7 @@ func (r *RestAPI) listUsersForPath(
 		return
 	}
 
+	batchCounter := 0
 	for i := r.Pagination.FirstIndex; i <= r.Pagination.PageLimit; i++ {
 		nextIndex := i
 		if scheme == PaginationSchemeItems {
@@ -245,6 +246,13 @@ func (r *RestAPI) listUsersForPath(
 		}
 		for _, pp := range p {
 			people <- pp
+		}
+
+		batchCounter++
+		if batchCounter >= r.BatchSize {
+			log.Printf("listUsersForPath waiting %d seconds for rate limit", r.BatchDelaySeconds)
+			time.Sleep(time.Second * time.Duration(r.BatchDelaySeconds))
+			batchCounter = 0
 		}
 	}
 }


### PR DESCRIPTION
### Fixed
- Use the `BatchSize` and `BatchDelaySeconds` parameters to wait for rate limiting on the list users endpoint.
- Reduce complexity of listUsersForPath by moving pagination scheme validation earlier in the process.